### PR TITLE
Update local-build.sh

### DIFF
--- a/local-build.sh
+++ b/local-build.sh
@@ -18,5 +18,5 @@ box build
 mv cdev.phar $TARGET_RELEASE_PATH
 cp cdev.phar.pubkey $TARGET_RELEASE_KEY_PATH
 
-rm $ALIAS
-ln -s $TARGET_RELEASE_PATH $ALIAS
+sudo rm $ALIAS
+sudo ln -s $TARGET_RELEASE_PATH $ALIAS


### PR DESCRIPTION
On Ubuntu and in quite a few linux based systems, /usr/local/bin/ is owed by root and so we need to make sure that we issue the sudo command on command that have an effect on that directory.

If you then the script won't copy of the file required to make cdev available across the system.